### PR TITLE
Implement fixes for radial quick menu

### DIFF
--- a/Profile/scripts/Config/CONFIG.lua
+++ b/Profile/scripts/Config/CONFIG.lua
@@ -34,7 +34,8 @@ config_table = {
     Melee_Power = 700,
 	ReticleAlwaysOn =true,
 	UI_Follows_View =true,
-	DarkerDarks=false
+	DarkerDarks=false,
+	RadialQuickMenu=true,
 	--HandIndex=2
 	--isRhand = true	
 }
@@ -75,6 +76,7 @@ MeleePower = config_table.Melee_Power
 ReticleAlwaysOn = config_table.ReticleAlwaysOn
 UIFollowsView = config_table.UI_Follows_View
 DarkerDarks=config_table.DarkerDarks
+RadialQuickMenu=config_table.RadialQuickMenu
 --isRhand = config_table.isRhand
 
 
@@ -169,7 +171,8 @@ uevr.sdk.callbacks.on_draw_ui(function()
 
     imgui.text("Features")
 	
-	UIFollowsView = create_checkbox("UI Follows View", "UI Follows View")
+	UIFollowsView = create_checkbox("UI Follows View", "UI_Follows_View")
+	RadialQuickMenu = create_checkbox("Motion Controlled Radial Quick Menu", "RadialQuickMenu")
     Enable_Lumen_Indoors = create_checkbox("Enable Lumen Indoors", "Enable_Lumen_Indoors")
     Faster_Projectiles = create_checkbox("Faster Projectiles", "Faster_Projectiles")
 	--ReticleAlwaysOn = create_checkbox("Reticle Always On", "Reticle Always On")

--- a/Profile/scripts/RadialQuickMenu.lua
+++ b/Profile/scripts/RadialQuickMenu.lua
@@ -1,6 +1,7 @@
 require(".\\Trackers\\Trackers")
 require(".\\Subsystems\\UEHelper")
 require(".\\Subsystems\\ControlInput")
+require(".\\Config\\CONFIG")
 local api = uevr.api
 local QuickMenuJustOpened=false
 local QuickMenuOriginalPosition
@@ -63,7 +64,26 @@ end
 
 uevr.sdk.callbacks.on_pre_engine_tick(
 function(engine, delta)
-if QuickMenu==true then
+--In rare event radial quick menu option is changed midstream, reset state
+if not RadialQuickMenu then
+	QuickMenuJustOpened=false
+	QuickMenuSelectedSlot=0
+	QuickMenuSimulatedStickX=0
+	QuickMenuSimulatedStickY=0
+	if QuickMenuSloMoActive then
+		QuickMenuSloMoActive=false
+		local playerController = api:get_player_controller(0)
+		if playerController ~= nil then
+			local CheatManager = playerController.CheatManager
+			if CheatManager ~= nil then
+				CheatManager:Slomo(1.0)
+			end
+		end
+	end
+end
+
+--If Quick menu is open and option for RadialQuickMenu is on, then activate slow motion, grab initial position of player's hand to compare to movement while menu open
+if QuickMenu==true and RadialQuickMenu then
 	if not QuickMenuJustOpened then
 		QuickMenuJustOpened=true
 		QuickMenuOriginalPosition=right_hand_component:K2_GetComponentLocation()
@@ -87,8 +107,8 @@ end)
 
 uevr.sdk.callbacks.on_xinput_get_state(function(retval, user_index, state)
 
-
-if QuickMenu==false then
+--If Quick menu no longer open, return time to normal scale
+if QuickMenu==false and RadialQuickMenu then
 	if QuickMenuSloMoActive then
 		QuickMenuSloMoActive=false
 		local playerController = api:get_player_controller(0)
@@ -101,7 +121,9 @@ if QuickMenu==false then
 	end
 end
 
-if QuickMenu==true and not isBow and uevr.params.vr:get_mod_value("UI_FollowView") then
+--if QuickMenu==true and not isBow and uevr.params.vr:get_mod_value("UI_FollowView") then
+--If not holding the bow and quickmenu is open, use hand motion to simulate right stick input to rotate the selector
+if QuickMenu==true and not isBow and RadialQuickMenu then
 	if state ~= nil then
 		state.Gamepad.sThumbRX = QuickMenuSimulatedStickX
 		state.Gamepad.sThumbRY = QuickMenuSimulatedStickY

--- a/Profile/scripts/Subsystems/ControlInput.lua
+++ b/Profile/scripts/Subsystems/ControlInput.lua
@@ -1,8 +1,7 @@
 require(".\\Subsystems\\UEHelper")
+QuickMenu=false --needs to be global so other scripts like RadialQuickMenu can access state
 local api = uevr.api
-local QuickMenu=false
 local BbuttonNotPressedAfterMenu=false
- 
 local SprintState=false
 
 uevr.sdk.callbacks.on_xinput_get_state(
@@ -57,9 +56,9 @@ if isMenu==false then
 	end
 else BbuttonNotPressedAfterMenu=false end
 
-
-if not isMenu then
-	if not isSprinting  then
+--Do not take over stick if riding, otherwise cannot move horse
+if not isMenu and not isRiding then
+	if not isSprinting then
 		state.Gamepad.sThumbLX=0
 		state.Gamepad.sThumbLY=0
 


### PR DESCRIPTION
-Change controlinput.lua's value for quickmenu to global so radial quick menu can access it

-implement config option to turn radial quick menu on and off

-Removed disabled radialquickmenu.luabb

-fix horse riding breaking by adding check in ControlInput.lua for isRiding to avoid taking over the stick if riding

-MISC - UNRELATED - fix bug with UI follows view option in config.lua that had typo that made value always reset to false (UI Follow View --> UI_Follows_View)